### PR TITLE
Refactor: TagBottomSheet 애니메이션 추가 및 디자인 수정

### DIFF
--- a/src/assets/tagPlus.svg
+++ b/src/assets/tagPlus.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 5V19" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 12H19" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/PostForm/components/TagBottomSheet.tsx
+++ b/src/pages/PostForm/components/TagBottomSheet.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 
+import TagPlusIcon from '../../../assets/tagPlus.svg?react';
 import Spacing from '../../../components/Spacing';
 import { TagItem } from '../components/TagItem';
 
@@ -30,16 +31,20 @@ export const TagBottomSheet = ({ onAddTags, onClose }: TagBottomSheetProps) => {
   };
 
   return (
-    <div className="z-999 absolute left-0 top-0 flex h-full w-full items-end bg-[rgba(0,0,0,0.5)]">
-      <div className="min-h-[50%] w-full rounded-t-[20px] bg-white p-5">
-        <div className="flex justify-between gap-2">
+    <div
+      className="z-999 absolute left-0 top-0 flex h-full w-full items-end bg-[rgba(0,0,0,0.5)]"
+      onClick={handleClose}
+    >
+      <div
+        className="animate-slide-up min-h-[50%] w-full rounded-t-[20px] bg-white p-5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-2">
           <input
-            className="border-light-gray flex h-9 grow rounded-[10px] border px-[11px] py-2"
+            className="flex h-9 grow rounded-[10px] bg-[#E6E6E6] px-[11px] py-2"
             ref={inputRef}
           />
-          {/* TODO: 버튼 디자인 요청 필요 */}
-          <button onClick={handleAddTag}>추가</button>
-          <button onClick={handleClose}>닫기</button>
+          <TagPlusIcon onClick={handleAddTag} />
         </div>
         <Spacing size={1} />
         <div className="flex flex-wrap gap-1">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,15 @@ export default {
         'light-gray': '#D9D9D9',
         gray: '#838383',
       },
+      keyframes: {
+        slideUp: {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'slide-up': 'slideUp 0.3s ease-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 개요
- 리팩토링

## 변경 사항

- TagBottomSheet 디자인을 수정했습니다

  - 렌더링 될 때 컨테이너 영역 애니메이션 추가
  - 태그 입력칸 border 삭제 및 bg 추가
  - `닫기` 버튼 삭제, 배경 클릭 시 닫히도록 이벤트 핸들러 추가

![tagsheet](https://github.com/user-attachments/assets/c50f71af-938b-4937-8a32-bba3c10c2cc8)

## To. 리뷰어

- 지금 TagBottomSheet가 조건부 렌더링 되고 있어서, 조건이 바뀌는 순간 바로 사라지게 됩니다
  그래서 닫히는 애니메이션 구현을 어떻게 해야할지 잘 안 떠올라서 일단 이대로 올립니다 🤔
  좋은 아이디어 있으면 조언 부탁드립니다!

- 제가 PR 올리고 브랜치 이름을 바꾸는 바람에 다시 업로드 합니다 죄송해요 😅