### PR TITLE
Feature: 이야기 피드 페이지에서 API 모킹

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "typescript-eslint": "^8.7.0",
     "vite": "^5.4.8",
     "vite-plugin-svgr": "^4.3.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,291 @@
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const PACKAGE_VERSION = '2.6.5';
+const INTEGRITY_CHECKSUM = 'ca7800994cc8bfb5eb961e037c877074';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
+
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id;
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      });
+      break;
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event;
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  // Generate unique request ID.
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    (async function () {
+      const responseClone = response.clone();
+
+      sendToClient(
+        client,
+        {
+          type: 'RESPONSE',
+          payload: {
+            requestId,
+            isMockedResponse: IS_MOCKED_RESPONSE in response,
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            body: responseClone.body,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+          },
+        },
+        [responseClone.body],
+      );
+    })();
+  }
+
+  return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (activeClientIds.has(event.clientId)) {
+    return client;
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible';
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event;
+
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = request.clone();
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers);
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    headers.delete('accept', 'msw/passthrough');
+
+    return fetch(requestClone, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Notify the client that a request has been intercepted.
+  const requestBuffer = await request.arrayBuffer();
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        url: request.url,
+        mode: request.mode,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        cache: request.cache,
+        credentials: request.credentials,
+        destination: request.destination,
+        integrity: request.integrity,
+        redirect: request.redirect,
+        referrer: request.referrer,
+        referrerPolicy: request.referrerPolicy,
+        body: requestBuffer,
+        keepalive: request.keepalive,
+      },
+    },
+    [requestBuffer],
+  );
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data);
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough();
+    }
+  }
+
+  return passthrough();
+}
+
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(message, [channel.port2].concat(transferrables.filter(Boolean)));
+  });
+}
+
+async function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error();
+  }
+
+  const mockedResponse = new Response(response.body, response);
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  });
+
+  return mockedResponse;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,8 +4,19 @@ import { createRoot } from 'react-dom/client';
 
 import App from './App.tsx';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+async function enableMocking() {
+  if (import.meta.env.MODE !== 'development') {
+    return;
+  }
+
+  const { worker } = await import('./mocks/browsers');
+  return worker.start();
+}
+
+enableMocking().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+});

--- a/src/mocks/browsers.ts
+++ b/src/mocks/browsers.ts
@@ -1,0 +1,15 @@
+import { setupWorker } from 'msw/browser';
+
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);
+
+export const startWorker = async () => {
+  try {
+    await worker.start({
+      onUnhandledRequest: 'bypass',
+    });
+  } catch (error) {
+    console.error('[MSW] Failed to start Mock Service Worker:', error);
+  }
+};

--- a/src/mocks/handlers/feed.ts
+++ b/src/mocks/handlers/feed.ts
@@ -1,0 +1,170 @@
+import { http, HttpResponse } from 'msw';
+
+interface User {
+  userId: number;
+  nickName: string;
+  profileImageUrl: string;
+  part: string;
+}
+
+const postDummy = [
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 1,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+  {
+    authorInfo: {
+      authorId: 2,
+      authorNickName: 'user',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 2,
+    title: '제목2',
+    content: '내용2',
+    likeCount: 0,
+    isLike: false,
+    tags: [],
+    postImageUrl: '',
+  },
+  {
+    authorInfo: {
+      authorId: 3,
+      authorNickName: 'user2',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 3,
+    title: '제목3',
+    content: '내용3',
+    likeCount: 0,
+    isLike: false,
+    tags: [],
+    postImageUrl: '',
+  },
+  {
+    authorInfo: {
+      authorId: 3,
+      authorNickName: 'user2',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 4,
+    title: '제목4',
+    content: '내용4',
+    likeCount: 0,
+    isLike: false,
+    tags: [],
+    postImageUrl: '',
+  },
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 11,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 21,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 31,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 41,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+  {
+    authorInfo: {
+      authorId: 1,
+      authorNickName: 'admin',
+      authorProfileImageUrl: 'img',
+    },
+    createdAt: '2024-11-21 15:46:57',
+    postId: 51,
+    title: '제목1',
+    content:
+      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
+    likeCount: 1,
+    isLike: true,
+    tags: ['ANGRY', 'HAPPY'],
+    postImageUrl: 'img',
+  },
+];
+
+const recommendUserDummy: User[] = [
+  { userId: 1, nickName: 'n1', profileImageUrl: 'img', part: '건설업' },
+  { userId: 2, nickName: 'n2', profileImageUrl: 'img', part: '서비스업' },
+  { userId: 3, nickName: 'n3', profileImageUrl: 'img', part: '건설업' },
+];
+
+/**
+ * 해당 파일에서 생성한 handlers는 index.ts에서 import해야 합니다.
+ */
+export const feedHandlers = [
+  http.get('http://localhost:5173/posts', () => {
+    return HttpResponse.json(postDummy);
+  }),
+  http.get('http://localhost:5173/users/recommend', () => {
+    return HttpResponse.json(recommendUserDummy);
+  }),
+];

--- a/src/mocks/handlers/feed.ts
+++ b/src/mocks/handlers/feed.ts
@@ -1,12 +1,5 @@
 import { http, HttpResponse } from 'msw';
 
-interface User {
-  userId: number;
-  nickName: string;
-  profileImageUrl: string;
-  part: string;
-}
-
 const postDummy = [
   {
     authorInfo: {
@@ -151,7 +144,7 @@ const postDummy = [
   },
 ];
 
-const recommendUserDummy: User[] = [
+const recommendUserDummy = [
   { userId: 1, nickName: 'n1', profileImageUrl: 'img', part: '건설업' },
   { userId: 2, nickName: 'n2', profileImageUrl: 'img', part: '서비스업' },
   { userId: 3, nickName: 'n3', profileImageUrl: 'img', part: '건설업' },

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,6 @@
+import { feedHandlers } from './feed';
+
+/**
+ * feed.ts에서 작성한 feedHandlers를 handlers 배열에 삽입합니다.
+ */
+export const handlers = [...feedHandlers];

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -1,191 +1,40 @@
+import { useEffect, useState } from 'react';
+
 import { Filter } from './components/Filter';
 import { PostItem } from './components/PostItem';
 import { RecommendUser } from './components/RecommendUser';
 import Spacing from '../../components/Spacing';
 
-// TODO: 서버 연결
-const postDummy = [
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 1,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-  {
-    authorInfo: {
-      authorId: 2,
-      authorNickName: 'user',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 2,
-    title: '제목2',
-    content: '내용2',
-    likeCount: 0,
-    isLike: false,
-    tags: [],
-    postImageUrl: '',
-  },
-  {
-    authorInfo: {
-      authorId: 3,
-      authorNickName: 'user2',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 3,
-    title: '제목3',
-    content: '내용3',
-    likeCount: 0,
-    isLike: false,
-    tags: [],
-    postImageUrl: '',
-  },
-  {
-    authorInfo: {
-      authorId: 3,
-      authorNickName: 'user2',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 4,
-    title: '제목4',
-    content: '내용4',
-    likeCount: 0,
-    isLike: false,
-    tags: [],
-    postImageUrl: '',
-  },
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 11,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 21,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 31,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 41,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-  {
-    authorInfo: {
-      authorId: 1,
-      authorNickName: 'admin',
-      authorProfileImageUrl: 'img',
-    },
-    createdAt: '2024-11-21 15:46:57',
-    postId: 51,
-    title: '제목1',
-    content:
-      '안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 안녕하세요. 저는 한국에 온 지 1년이 된 외국인 노동자입니다. 최근 몇 달 동안 일한 임금이 제대로 지급되지 않아 정말 막막한 상황입니다. 매번 월급날이 지나고 나면 ‘이번 주에는 줄게’라는 약속 ',
-    likeCount: 1,
-    isLike: true,
-    tags: ['ANGRY', 'HAPPY'],
-    postImageUrl: 'img',
-  },
-];
-
-const recommendUserDummy = [
-  { userId: 1, nickName: 'n1', profileImageUrl: 'img', part: '건설업' },
-  { userId: 2, nickName: 'n2', profileImageUrl: 'img', part: '서비스업' },
-  { userId: 3, nickName: 'n3', profileImageUrl: 'img', part: '건설업' },
-];
-
 export const Feed = () => {
+  // TODO: 서버 스키마와 동일한 타입 생성
+  const [recommendUsers, setRecommendUsers] = useState<any[]>([]);
+  const [postList, setPostList] = useState<any[]>([]);
+
+  useEffect(() => {
+    // TODO: api 함수로 분리
+    const fetchPostList = async () => {
+      const response = await fetch('http://localhost:5173/posts');
+      const data = await response.json();
+      setPostList(data);
+    };
+    const fetchRecommendUsers = async () => {
+      const response = await fetch('http://localhost:5173/users/recommend');
+      const data = await response.json();
+      setRecommendUsers(data);
+    };
+
+    fetchPostList();
+    fetchRecommendUsers();
+  }, []);
+
   return (
     <div>
       <Filter />
-      {postDummy.map(
-        ({
-          authorInfo,
-          createdAt,
-          postId,
-          title,
-          content,
-          likeCount,
-          isLike,
-          tags,
-          postImageUrl,
-        }) => (
-          <PostItem
-            key={postId}
-            authorInfo={authorInfo}
-            createdAt={createdAt}
-            postId={postId}
-            title={title}
-            content={content}
-            likeCount={likeCount}
-            isLike={isLike}
-            tags={tags}
-            postImageUrl={postImageUrl}
-          />
-        ),
-      )}
+      {postList.map((post) => (
+        <PostItem key={post.postId} {...post} />
+      ))}
       <Spacing size={1.25} />
-      <RecommendUser userList={recommendUserDummy} />
+      <RecommendUser userList={recommendUsers} />
     </div>
   );
 };


### PR DESCRIPTION
## 개요
- 신규 피쳐

## 변경 사항
- msw를 사용한 API 모킹 코드를 추가했습니다. 네트워크 탭에서 요청과 응답 확인 가능합니다.
  
  ![image](https://github.com/user-attachments/assets/1891a294-adf0-4cd0-95f1-8b361eb3d44e)

  - 포스트 리스트 / 사용자 추천 2곳에 사용했습니다


## To. 리뷰어

- 모킹 성공 여부를 판단해야 해서 페이지 컴포넌트의 useEffect 내에서 데이터 페칭을 진행합니다.
  이는 추후에 API 함수 혹은 tanstack-query 훅으로 수정될 예정입니다

- 같은 이유로 any 타입을 사용한 곳이 있습니다. 서버 스키마와 동일한 타입을 생성해서 수정할 예정입니다.