### PR TITLE
Refactor: Feed 페이지 직종 필터와 정렬 필터 분리

### DIFF
--- a/src/api/feed.api.ts
+++ b/src/api/feed.api.ts
@@ -2,8 +2,10 @@ import { PostListOption, RecommendUserOption } from '@/types/feedOption';
 
 import api from './index';
 
-export const getPostList = async ({ page, sortType }: PostListOption) => {
-  const { data } = await api.get(`/posts?page=${page}&size=${5}&sortType=${sortType}`);
+export const getPostList = async ({ page, sortType, part }: PostListOption) => {
+  const { data } = await api.get(
+    `/posts?page=${page}&size=${5}&sortType=${sortType}${part !== '' ? `&part=${part}` : ''}`,
+  );
   return data;
 };
 

--- a/src/hooks/queries/feed.query.ts
+++ b/src/hooks/queries/feed.query.ts
@@ -2,12 +2,18 @@ import { useSuspenseQuery, InfiniteData, useSuspenseInfiniteQuery } from '@tanst
 
 import { getPostDetail, getPostList, getRecommendUsers } from '@/api/feed.api';
 import { RecommendUserOption } from '@/types/feedOption';
-import { FilterType } from '@/types/filterType';
+import { FilterType, SortType } from '@/types/filterType';
 import { PostDetailType, PostItemType } from '@/types/postType';
 
 const POST_PER_PAGE = 5;
 
-export const useGetPostList = (sortType: FilterType) => {
+export const useGetPostList = ({
+  currentSortType,
+  currentPartType,
+}: {
+  currentSortType: SortType;
+  currentPartType: FilterType;
+}) => {
   return useSuspenseInfiniteQuery<
     PostItemType[],
     Error,
@@ -15,8 +21,9 @@ export const useGetPostList = (sortType: FilterType) => {
     string[],
     number
   >({
-    queryKey: ['postList', sortType],
-    queryFn: ({ pageParam }) => getPostList({ page: pageParam, sortType }),
+    queryKey: ['postList', currentSortType, currentPartType],
+    queryFn: ({ pageParam }) =>
+      getPostList({ page: pageParam, sortType: currentSortType, part: currentPartType }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.length === POST_PER_PAGE ? allPages.length : undefined;

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -1,9 +1,13 @@
+import { useEffect, useState } from 'react';
+
 import { useSearchParams } from 'react-router-dom';
 
+import LikeDescIcon from '@/assets/feed/filter_like.svg?react';
+import CreatedAtDescIcon from '@/assets/feed/filter_time.svg?react';
 import Spacing from '@/components/Spacing';
 import { useGetPostList, useGetRecommendUsers } from '@/hooks/queries/feed.query';
 import { useScrollObserve } from '@/hooks/useScrollObserve';
-import { FilterType } from '@/types/filterType';
+import { FilterType, SortType } from '@/types/filterType';
 import { PostItemType } from '@/types/postType';
 
 import { EmptyFeed } from './components/EmptyFeed';
@@ -12,10 +16,21 @@ import { PostItem } from './components/PostItem';
 import { RecommendUser } from './components/RecommendUser';
 
 export const Feed = () => {
-  const [searchParams] = useSearchParams();
-  const currentSortType = (searchParams.get('sortType') || 'CREATED_AT_DESC') as FilterType;
+  const [isFilterVisible, setIsFilterVisible] = useState(false);
 
-  const { data: postList, isPending, fetchNextPage, hasNextPage } = useGetPostList(currentSortType);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentSortType = (searchParams.get('sortType') || 'CREATED_AT_DESC') as SortType;
+  const currentPartType = (searchParams.get('part') || '') as FilterType;
+
+  const {
+    data: postList,
+    isPending,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetPostList({
+    currentSortType,
+    currentPartType,
+  });
   const { data: recommendUsers } = useGetRecommendUsers({});
 
   const allPostCount = (postList ? postList.pages.flat() : []).length;
@@ -26,11 +41,31 @@ export const Feed = () => {
     hasNextPage,
   });
 
+  useEffect(() => {
+    if (!searchParams.get('sortType')) {
+      setSearchParams({ sortType: 'CREATED_AT_DESC' });
+    }
+  }, [searchParams, setSearchParams]);
+
   return (
     <div>
-      <Filter />
+      <div className="flex items-center justify-end">
+        {isFilterVisible == false && (
+          <div className="ml-2 flex gap-2">
+            <CreatedAtDescIcon
+              className={currentSortType === 'CREATED_AT_DESC' ? 'text-primary' : 'text-[#979797]'}
+              onClick={() => setSearchParams({ sortType: 'CREATED_AT_DESC' })}
+            />
+            <LikeDescIcon
+              className={currentSortType === 'LIKE_DESC' ? 'text-primary' : 'text-[#979797]'}
+              onClick={() => setSearchParams({ sortType: 'LIKE_DESC' })}
+            />
+          </div>
+        )}
+        <Filter isFilterVisible={isFilterVisible} setIsFilterVisible={setIsFilterVisible} />
+      </div>
       {allPostCount === 0 ? (
-        <EmptyFeed sortType={currentSortType} />
+        <EmptyFeed filterType={currentPartType} />
       ) : (
         <div>
           {postList.pages.flatMap((page) =>

--- a/src/pages/Feed/components/EmptyFeed.tsx
+++ b/src/pages/Feed/components/EmptyFeed.tsx
@@ -1,14 +1,12 @@
 import { FilterType } from '@/types/filterType';
 import { translatePart } from '@/utils/translatePart';
 
-export const EmptyFeed = ({ sortType }: { sortType: FilterType }) => {
-  if (sortType == 'LIKE_DESC' || sortType == 'CREATED_AT_DESC') return;
-
+export const EmptyFeed = ({ filterType }: { filterType: FilterType }) => {
   return (
     <div className="flex h-96 flex-col justify-center whitespace-pre-line text-center">
       <p>
-        현재 <span className="text-[#228CFF]">{translatePart(sortType)}</span> 직종에 관한 이야기가
-        없습니다.
+        현재 <span className="text-[#228CFF]">{translatePart(filterType)}</span> 직종에 관한
+        이야기가 없습니다.
         <br />이 분야에서 일하고 계신다면 경험을 들려주세요!
       </p>
     </div>

--- a/src/pages/Feed/components/Filter.tsx
+++ b/src/pages/Feed/components/Filter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
 import { useSearchParams } from 'react-router-dom';
 
@@ -7,18 +7,14 @@ import AgricultureIcon from '@/assets/feed/filter_agriculture.svg?react';
 import ConstructionIcon from '@/assets/feed/filter_construction.svg?react';
 import FisheriesIcon from '@/assets/feed/filter_fisheries.svg?react';
 import HousecareIcon from '@/assets/feed/filter_housecare.svg?react';
-import LikeDescIcon from '@/assets/feed/filter_like.svg?react';
 import LogisticsIcon from '@/assets/feed/filter_logistics.svg?react';
 import ManufacturingIcon from '@/assets/feed/filter_manufacturing.svg?react';
 import ProfessionalIcon from '@/assets/feed/filter_professional.svg?react';
 import ServiceIcon from '@/assets/feed/filter_service.svg?react';
-import CreatedAtDescIcon from '@/assets/feed/filter_time.svg?react';
 import FilterCloseIcon from '@/assets/feed/filterClose.svg?react';
 import { FilterType } from '@/types/filterType';
 
 const FILTER_TYPE: { filter: FilterType; icon: React.ReactNode }[] = [
-  { filter: 'CREATED_AT_DESC', icon: <CreatedAtDescIcon /> },
-  { filter: 'LIKE_DESC', icon: <LikeDescIcon /> },
   { filter: 'MANUFACTURING', icon: <ManufacturingIcon /> },
   { filter: 'CONSTRUCTION', icon: <ConstructionIcon /> },
   { filter: 'LOGISTICS', icon: <LogisticsIcon /> },
@@ -29,20 +25,33 @@ const FILTER_TYPE: { filter: FilterType; icon: React.ReactNode }[] = [
   { filter: 'PROFESSIONAL', icon: <ProfessionalIcon /> },
 ];
 
-export const Filter = () => {
-  const [isFilterVisible, setIsFilterVisible] = useState(false);
+export const Filter = ({
+  isFilterVisible,
+  setIsFilterVisible,
+}: {
+  isFilterVisible: boolean;
+  setIsFilterVisible: Dispatch<SetStateAction<boolean>>;
+}) => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const currentSortType = searchParams.get('sortType') || 'CREATED_AT_DESC';
+  const [currentPartType, setCurrentPartType] = useState(searchParams.get('part') || '');
 
   const handleIsFilterVisible = () => {
     setIsFilterVisible((prev) => !prev);
   };
 
-  useEffect(() => {
-    if (!searchParams.get('sortType')) {
-      setSearchParams({ sortType: 'CREATED_AT_DESC' });
+  const updateSearchParams = (filter: string) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+
+    if (newSearchParams.has('part')) {
+      newSearchParams.delete('part');
+      setCurrentPartType('');
+    } else {
+      newSearchParams.set('part', filter);
+      setCurrentPartType(filter);
     }
-  }, [searchParams, setSearchParams]);
+
+    setSearchParams(newSearchParams);
+  };
 
   return (
     <div className="flex min-h-8 items-center justify-end">
@@ -53,8 +62,8 @@ export const Filter = () => {
             {FILTER_TYPE.map(({ filter, icon }) => (
               <div
                 key={filter}
-                onClick={() => setSearchParams({ sortType: filter })}
-                className={currentSortType === filter ? 'text-primary' : 'text-[#979797]'}
+                onClick={() => updateSearchParams(filter)}
+                className={currentPartType === filter ? 'text-primary' : 'text-[#979797]'}
               >
                 {icon}
               </div>

--- a/src/types/feedOption.ts
+++ b/src/types/feedOption.ts
@@ -1,8 +1,9 @@
-import { FilterType } from './filterType';
+import { FilterType, SortType } from './filterType';
 
 export interface PostListOption {
   page?: number;
-  sortType: FilterType;
+  sortType: SortType;
+  part: FilterType | '';
 }
 
 export interface RecommendUserOption {

--- a/src/types/filterType.ts
+++ b/src/types/filterType.ts
@@ -1,6 +1,6 @@
+export type SortType = 'CREATED_AT_DESC' | 'LIKE_DESC';
+
 export type FilterType =
-  | 'CREATED_AT_DESC'
-  | 'LIKE_DESC'
   | 'MANUFACTURING'
   | 'CONSTRUCTION'
   | 'LOGISTICS'


### PR DESCRIPTION
## 개요
- 기능 수정

## 변경 사항
- Feed 페이지에서 직종 필터와 정렬 필터를 분리했어요
- 실행은 라이브로 보여드렷습니다

## To. 리뷰어
<!-- 리뷰 과정에서 주목할 점이나, 리뷰어의 의견이 필요한 부분에 대해 적습니다. -->
<!-- 예: 함수 XX의 이름을 변경하고 싶은데, 더 좋은 명칭이 있을까요? -->
